### PR TITLE
Replace &bullet; with &bull; in invite email

### DIFF
--- a/configs/notifications/invite.template.html
+++ b/configs/notifications/invite.template.html
@@ -178,7 +178,7 @@ h3 {
                 <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation" style="width: 570px; margin: 0 auto; padding: 0; -premailer-width: 570px; -premailer-cellpadding: 0; -premailer-cellspacing: 0; text-align: center;">
                   <tr>
                     <td class="content-cell" align="center" style="word-break: break-word; font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif; font-size: 16px; padding: 20px;">
-                      <p class="f-fallback sub align-center" style="margin: .4em 0 1.1875em; line-height: 1.625; text-align: center; font-size: 12px; color: #686868;">&copy; 2020 Moov Financial, Inc. &bullet; <a href="https://moov.io" class="fancy-link" style="color: #0D80F2; background-color: rgba(13,128,242,.1); text-decoration-style: dotted; text-decoration-thickness: 2px;">moov.io</a></p>
+                      <p class="f-fallback sub align-center" style="margin: .4em 0 1.1875em; line-height: 1.625; text-align: center; font-size: 12px; color: #686868;">&copy; 2020 Moov Financial, Inc. &bull; <a href="https://moov.io" class="fancy-link" style="color: #0D80F2; background-color: rgba(13,128,242,.1); text-decoration-style: dotted; text-decoration-thickness: 2px;">moov.io</a></p>
                       <p class="f-fallback sub align-center" style="margin: .4em 0 1.1875em; line-height: 1.625; text-align: center; font-size: 12px; color: #686868;">
                         You’re receiving our system emails so that we can keep you in the loop with updates to your account.
                       </p>


### PR DESCRIPTION
To see if Go parser handles it properly. It was printing &amp;bullet; but it's handling &copy; properly.