### PR TITLE
update oidc photo url if different

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -576,6 +576,7 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/authn/api_authn.go
+++ b/pkg/authn/api_authn.go
@@ -69,7 +69,7 @@ func (c *authnAPIController) Authenticated(w http.ResponseWriter, r *http.Reques
 			TenantID:     session.TenantID,
 		}
 
-		cookie, loggedIn, err := c.service.LoginWithCredentials(r, login, session.State, session.IP)
+		cookie, loggedIn, err := c.service.LoginWithCredentials(r, login, session.State, session.IP, session.ImageUrl)
 		if err != nil {
 			c.logger.Error().LogError("Not able to exchange login token for session token", err)
 			w.WriteHeader(404)

--- a/pkg/authn/api_authn_test.go
+++ b/pkg/authn/api_authn_test.go
@@ -322,6 +322,30 @@ func Test_Login_Success(t *testing.T) {
 	s.assert.Nil(err)
 }
 
+func Test_Login_Updates_PhotoURL_Success(t *testing.T) {
+	s := Setup(t)
+
+	registerSession := RegisterRandomIdentity(s)
+
+	loginSession := LoginSession{}
+	s.fuzz.Fuzz(&loginSession)
+	imgUrl := "http://profiles.com/123.jpg"
+	loginSession.Register.ImageUrl = &imgUrl
+
+	// These are the values that have to match up to what was registered.
+	loginSession.CredentialID = registerSession.CredentialID
+	loginSession.TenantID = registerSession.TenantID
+	loginSession.Scopes = []string{"authenticate", "finished"}
+
+	// Test if we can login with it.
+	c := s.NewClient(loginSession)
+	loggedIn, resp, err := c.AuthenticationApi.Authenticated(context.Background())
+	s.assert.NotNil(loggedIn)
+	s.assert.Equal(loginSession.Register.ImageUrl, loggedIn.ImageUrl)
+	s.assert.Equal(200, resp.StatusCode)
+	s.assert.Nil(err)
+}
+
 func RegisterRandomIdentity(s Scope) LoginSession {
 	req := httptest.NewRequest("GET", "https://local.moov.io", strings.NewReader(""))
 	req.Header.Add("X-Forwarded-For", "1.2.3.4")

--- a/pkg/authn/service.go
+++ b/pkg/authn/service.go
@@ -124,9 +124,11 @@ func (s *authnService) LoginWithCredentials(req *http.Request, login client.Logi
 	}
 
 	if photoURL != nil && identity.ImageUrl != photoURL {
-		logCtx.Info().Log("OIDC image updated")
-		logCtx.Info().WithKeyValue("Old ImageUrl", *identity.ImageUrl)
-		logCtx.Info().WithKeyValue("New ImageUrl", *photoURL)
+		logCtx.WithMap(map[string]string{
+			"photo_old": fmt.Sprintf("%+v", identity.ImageUrl),
+			"photo_new": *photoURL,
+			"identity_id": identity.IdentityID,
+		}).Log("Photo URL Updated")
 		identity.ImageUrl = photoURL
 		s.identities.UpdateInsecure(identity)
 	}

--- a/pkg/authn/service.go
+++ b/pkg/authn/service.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	api "github.com/moov-io/identity/pkg/api"
+	"github.com/moov-io/identity/pkg/api"
 	"github.com/moov-io/identity/pkg/client"
 	"github.com/moov-io/identity/pkg/credentials"
 	"github.com/moov-io/identity/pkg/identities"
@@ -125,8 +125,8 @@ func (s *authnService) LoginWithCredentials(req *http.Request, login client.Logi
 
 	if photoURL != nil && identity.ImageUrl != photoURL {
 		logCtx.WithMap(map[string]string{
-			"photo_old": fmt.Sprintf("%+v", identity.ImageUrl),
-			"photo_new": *photoURL,
+			"photo_old":   fmt.Sprintf("%+v", identity.ImageUrl),
+			"photo_new":   *photoURL,
 			"identity_id": identity.IdentityID,
 		}).Log("Photo URL Updated")
 		identity.ImageUrl = photoURL

--- a/pkg/client/api_identities.go
+++ b/pkg/client/api_identities.go
@@ -290,7 +290,7 @@ func (a *IdentitiesApiService) ListIdentities(ctx _context.Context) ([]Identity,
 }
 
 /*
-UpdateIdentity Update a specific Identity
+UpdateIdentity UpdateInsecure a specific Identity
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param identityID ID of the Identity to lookup
  * @param updateIdentity

--- a/pkg/identities/api.go
+++ b/pkg/identities/api.go
@@ -110,7 +110,7 @@ func (c *controller) ListIdentities(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// UpdateIdentity - Update a specific Identity
+// UpdateIdentity - UpdateInsecure a specific Identity
 func (c *controller) UpdateIdentity(w http.ResponseWriter, r *http.Request) {
 	tmw.WithClaimsFromRequest(w, r, func(claims tmw.TumblerClaims) {
 		params := mux.Vars(r)

--- a/pkg/identities/repo_identities.go
+++ b/pkg/identities/repo_identities.go
@@ -155,7 +155,8 @@ func (r *sqlIdentityRepo) update(updated client.Identity) (*client.Identity, err
 			status = ?,
 			disabled_on = ?,
 			disabled_by = ?,
-			last_updated_on = ?
+			last_updated_on = ?,
+			photo_url = ?
 		WHERE
 			tenant_id = ? AND
 			identity_id = ?
@@ -172,6 +173,7 @@ func (r *sqlIdentityRepo) update(updated client.Identity) (*client.Identity, err
 		updated.DisabledOn,
 		updated.DisabledBy,
 		updated.LastUpdatedOn,
+		updated.ImageUrl,
 
 		updated.TenantID,
 		updated.IdentityID)

--- a/pkg/identities/service_identities.go
+++ b/pkg/identities/service_identities.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
-	api "github.com/moov-io/identity/pkg/api"
+	"github.com/moov-io/identity/pkg/api"
 	"github.com/moov-io/identity/pkg/client"
 	"github.com/moov-io/identity/pkg/stime"
 	tmw "github.com/moov-io/tumbler/pkg/middleware"
@@ -20,6 +20,8 @@ type Service interface {
 
 	Register(register client.Register, invite *client.Invite) (*client.Identity, error)
 	GetIdentityByID(identityID string) (*client.Identity, error)
+
+	UpdateInsecure(identity *client.Identity) (*client.Identity, error)
 }
 
 type service struct {
@@ -232,4 +234,14 @@ func (s *service) GetIdentityByID(identityID string) (*client.Identity, error) {
 	}
 
 	return i, nil
+}
+
+// UpdateInsecure - Updates an Identity with new values
+func (s *service) UpdateInsecure(identity *client.Identity) (*client.Identity, error) {
+	u, e := s.repository.update(*identity)
+	if e != nil {
+		return nil, e
+	}
+
+	return u, nil
 }

--- a/pkg/identities/testutils/service_single_identity.go
+++ b/pkg/identities/testutils/service_single_identity.go
@@ -24,6 +24,10 @@ type singleService struct {
 	identity client.Identity
 }
 
+func (s *singleService) UpdateInsecure(identity *client.Identity) (*client.Identity, error) {
+	panic(ErrNotImplemented)
+}
+
 func (s *singleService) DisableIdentity(claims tmw.TumblerClaims, identityID string) error {
 	panic(ErrNotImplemented)
 }


### PR DESCRIPTION
This PR will update the identity ImageUrl if the OIDC provider returns something different than we have. We basically always want to have the most current image from the oidc provider.